### PR TITLE
Cambiar URL base para apuntar al subdominio de murcialab

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseurl: https://MurciaLab.github.io/PMP
+baseurl: http://proyectos.murcialab.org
 languageCode: es-es
 theme: hugo-theme-stack
 paginate: 5


### PR DESCRIPTION
Cambio sencillo para utilizar el subdominio, pendiente de meterle https.